### PR TITLE
Miners no longer take simik related modules

### DIFF
--- a/prototypes/buildings/diamond-mine.lua
+++ b/prototypes/buildings/diamond-mine.lua
@@ -44,7 +44,7 @@ ENTITY {
     module_specification = {
         module_slots = 3
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     --crafting_categories = {"rare-earth"},
     mining_speed = 3,
     energy_source = {

--- a/prototypes/buildings/mo-mine.lua
+++ b/prototypes/buildings/mo-mine.lua
@@ -45,7 +45,7 @@ ENTITY {
     module_specification = {
         module_slots = 3
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     --crafting_categories = {"rare-earth"},
     mining_speed = 3.5,
     energy_source =

--- a/prototypes/buildings/regolite-mine.lua
+++ b/prototypes/buildings/regolite-mine.lua
@@ -45,7 +45,7 @@ ENTITY {
     module_specification = {
         module_slots = 3
     },
-    allowed_effects = {"consumption", "speed", "productivity", "pollution"},
+    allowed_effects = {"consumption", "speed", "productivity"},
     mining_speed = 1,
     energy_source = {
         type = "electric",


### PR DESCRIPTION
This is done by making these modules increase pollution output, and forbidding pollution modules in these miners.