### PR TITLE
Kovarex no longer tech dependent on productivity science in ShortPy

### DIFF
--- a/prototypes/updates/base-updates.lua
+++ b/prototypes/updates/base-updates.lua
@@ -1,6 +1,5 @@
 local FUN = require("__pycoalprocessing__/prototypes/functions/functions")
 
-
 --((TECHNOLOGY))--
 TECHNOLOGY('nuclear-fuel-reprocessing'):remove_prereq('production-science-pack'):remove_pack('production-science-pack')
 
@@ -8,19 +7,7 @@ TECHNOLOGY('speed-module-3'):add_prereq('speed-module-2')
 
 TECHNOLOGY('effectivity-module-3'):add_prereq('effectivity-module-2')
 
-data.raw.technology["kovarex-enrichment-process"].unit =
-{
-  ingredients =
-  {
-    {"automation-science-pack", 6},
-    {"logistic-science-pack", 4},
-    {"chemical-science-pack", 2},
-    {'military-science-pack', 2},
-    --{"production-science-pack", 1}
-  },
-  time = 30,
-  count = 150
-}
+TECHNOLOGY('kovarex-enrichment-process'):remove_prereq('production-science-pack'):remove_pack('production-science-pack')
 
 --((RECIPES))--
 


### PR DESCRIPTION
It didn't require productivity science packs, but it still had it as a tech prerequisite.

I've manually checked the patch with every version combination in the automated test suite, given that the automated test suite is broken over PyPH right now.

resolves pyanodon/pybugreports#116