### PR TITLE
Fixed vacuum pump fluid passthrough

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,6 +7,7 @@ Date: 2024-4-??
     - reduced pressurized vanadium pulp craft time from 2.5 -> 2 seconds. doubled input and output 100 -> 200
     - reduced pressurized water craft time from 2.5 -> 2 seconds. increased input and output rate from 200 -> 500
     - doubled vacuum craft time from 1 -> 2 seconds. increased vacuum output from 10 -> 200
+    - Fixed that vacuum pump passthrough fluidbox couldn't pass fluid to pipes
 ---------------------------------------------------------------------------------------------------
 Version: 2.0.11
 Date: 2024-4-1

--- a/prototypes/buildings/vacuum-pump-mk01.lua
+++ b/prototypes/buildings/vacuum-pump-mk01.lua
@@ -91,6 +91,7 @@ ENTITY {
             pipe_covers = DATA.Pipes.covers(false, true, false, false),
             base_area = 10,
             base_level = -1,
+	    height = 2,
             pipe_connections = {{type = "input-output", position = {-2.0, -0}},{type = "input-output", position = {2.0, -0}}}
         },
         {

--- a/prototypes/buildings/vacuum-pump-mk02.lua
+++ b/prototypes/buildings/vacuum-pump-mk02.lua
@@ -93,6 +93,7 @@ ENTITY {
             pipe_covers = DATA.Pipes.covers(false, true, false, false),
             base_area = 10,
             base_level = -1,
+	    height = 2,
             pipe_connections = {{type = "input-output", position = {-2.0, -0}},{type = "input-output", position = {2.0, -0}}}
         },
         {

--- a/prototypes/buildings/vacuum-pump-mk03.lua
+++ b/prototypes/buildings/vacuum-pump-mk03.lua
@@ -94,6 +94,7 @@ ENTITY {
             pipe_covers = DATA.Pipes.covers(false, true, false, false),
             base_area = 10,
             base_level = -1,
+	    height = 2,
             pipe_connections = {{type = "input-output", position = {-2.0, -0}},{type = "input-output", position = {2.0, -0}}}
         },
         {

--- a/prototypes/buildings/vacuum-pump-mk04.lua
+++ b/prototypes/buildings/vacuum-pump-mk04.lua
@@ -92,6 +92,7 @@ ENTITY {
             pipe_covers = DATA.Pipes.covers(false, true, false, false),
             base_area = 10,
             base_level = -1,
+	    height = 2,
             pipe_connections = {{type = "input-output", position = {-2.0, -0}},{type = "input-output", position = {2.0, -0}}}
         },
         {


### PR DESCRIPTION
<img width="643" alt="Screenshot 2024-04-07 at 5 59 19 PM" src="https://github.com/pyanodon/pyfusionenergy/assets/62921243/abfabe5a-8126-4e2e-8879-e8186cb5b7a1">
Previously, vacuum pumps' fluid input passthrough wasn't able to pass fluid to pipes (without a pump) due to having a too-low height. This PR fixes that.